### PR TITLE
fix resource_bundles format

### DIFF
--- a/snippets/podspec.json
+++ b/snippets/podspec.json
@@ -530,7 +530,7 @@
     "resource_bundles": {
         "prefix": "resource_bundles",
         "body": [
-            "resource_bundles = {\n    ${1:bundleName}' => ['${2:bundleFilePath}'],\n    ${3:...}' => ['${4:...}']\n}\n"
+            "resource_bundles = {\n    '${1:bundleName}' => ['${2:bundleFilePath}'],\n    '${3:...}' => ['${4:...}']\n}\n"
         ],
         "description": "resource_bundles = {'bundleName' => ['bundleFilePath'], '...' => ['...']}",
         "scope": ".podspec"


### PR DESCRIPTION
add missing single quote to resource_bundles snippet so the name of the bundle is properly stringified